### PR TITLE
fix: update binary path in Dockerfile for correct execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN go build -o azure-wakeup-db ./src
 
 # Run stage
 FROM scratch
-COPY --chmod=777 --from=builder /app/azure-wakeup-db .
+COPY --chmod=777 --from=builder /usr/local/bin/azure-wakeup-db .
 
-ENTRYPOINT ["./azure-wakeup-db"]
+ENTRYPOINT ["/usr/local/bin/azure-wakeup-db"]


### PR DESCRIPTION
This fixes execution of the Dockerfile from a GitHub action, as that overrides the WORKDIR command.

```
docker: 
Error response from daemon: 
failed to create task for container: 
failed to create shim task: 
OCI runtime create failed: 
runc create failed: 
unable to start container process: 
error during container init: 
exec: "./azure-wakeup-db": 
stat ./azure-wakeup-db: no such file or directory: unknown
```